### PR TITLE
Describe rustup as "version management" instead of "version control"

### DIFF
--- a/templates/learn/get-started.hbs
+++ b/templates/learn/get-started.hbs
@@ -13,9 +13,9 @@
       <h2>Installing Rust</h2>
       <div class="highlight highlight"></div>
     </header>
-    <h3><code>rustup</code>: the Rust installer and version control tool</h3>
+    <h3><code>rustup</code>: the Rust installer and version management tool</h3>
     <p>The primary way that folks install Rust is through a tool called <code>rustup</code> which is a Rust installer
-      and version control tool.</p>
+      and version management tool.</p>
     {{> tools/rustup }}
     <br /><br />
     <a href="/tools/install" class="button button-secondary">Learn more about installation</a>


### PR DESCRIPTION
Version control generally means something different, so I did a double take when I first read it. I think "version management" expresses what it's for clearly without having another established meaning.