### PR TITLE
Reword the "no runtime" section

### DIFF
--- a/templates/panels/language-values.hbs
+++ b/templates/panels/language-values.hbs
@@ -12,7 +12,7 @@
         <p class="f3 lh-copy">
           Rust is blazingly fast and memory-efficient: with no runtime or
           garbage collector, it can power performance-critical services, run on
-          embedded devices, or even integrate with other languages.
+          embedded devices, and easily integrate with other languages.
         </p>
       </section>
       <section class="flex flex-column mw8 measure-wide-l pv3 pt4-ns ph3-l">


### PR DESCRIPTION
The previous phrasing "or even integrate with other languages" seems to imply (to me) that integrating with other languages is an extraordinary thing. Many languages have FFIs, but where Rust excels is how easy to use its FFI is, not merely that it has one at all. Hence the slight rewording to emphasize this connotation.