### PR TITLE
Add docs.rs link to tools page

### DIFF
--- a/templates/tools/index.hbs
+++ b/templates/tools/index.hbs
@@ -124,7 +124,7 @@
         <p class="flex-grow-1">
           Cargo's doc builder makes it to so no API ever goes undocumented. It's
           available locally through <code>cargo doc</code>, and online for
-          public crates through docs.rs.
+          public crates through <a href="https://docs.rs" target="_blank" rel="noopener">docs.rs</a>.
         </p>
         <a href="https://docs.rs/" target="_blank" rel="noopener"
              class="button button-secondary">Go to site</a>


### PR DESCRIPTION
This PR adds a link to `docs.rs` where it's written in paragraph form in the Cargo Doc section.
This follows the same format as `crates.io` in the Install section above.