### PR TITLE
Change nomicon to 'nomicon in button on learn page

### DIFF
--- a/templates/learn/index.hbs
+++ b/templates/learn/index.hbs
@@ -163,7 +163,7 @@
 
           <a class="button button-secondary"
              href="https://doc.rust-lang.org/nomicon/index.html">
-            Read the nomicon
+            Read the 'nomicon
           </a>
         </div>
       </div>


### PR DESCRIPTION
This changes the "Read the nomicon" button to "Read the 'nomicon" to be consistent with the paragraph above.