### PR TITLE
In the tools page, remove a space in the Rust Language server link

### DIFF
--- a/templates/tools/index.hbs
+++ b/templates/tools/index.hbs
@@ -20,9 +20,7 @@
       <p>Whether you prefer working with code from the command line, or using
         rich graphical editors, there's a Rust integration available for your
         editor of choice. Or you can build your own using the
-        <a href="https://github.com/rust-lang-nursery/rls" target="_blank" rel="noopener">
-          Rust Language Server
-        </a>.
+        <a href="https://github.com/rust-lang-nursery/rls" target="_blank" rel="noopener">Rust Language Server</a>.
       </div>
     </div>
     {{> tools/editors }}


### PR DESCRIPTION
Fixes #422 