### PR TITLE
Change green from #46a092 to #398277

### DIFF
--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -5,7 +5,7 @@ $header-font: 'Alfa Slab One', serif;
 
 $gray: #454C52;
 $red: #C14566;
-$green: #46a092;
+$green: #398277;
 $purple: #403D58;
 $yellow: #FECD2F;
 


### PR DESCRIPTION
A background of `#46a092` has a contrast of 3.13 with a white foreground. A background of `#398277` improves the contrast to just over 4.5, which is required for AA compliance.

https://www.w3.org/TR/2008/REC-WCAG20-20081211/#visual-audio-contrast-contrast