### PR TITLE
Link all of "Send a fix here" text in footer

### DIFF
--- a/templates/footer.hbs
+++ b/templates/footer.hbs
@@ -32,8 +32,8 @@
 
     </div>
     <div class="attribution">
-      Maintained by the Rust Team. See a typo? Send a fix
-      <a href="https://github.com/rust-lang/beta.rust-lang.org" target="_blank" rel="noopener">here</a>!
+      Maintained by the Rust Team. See a typo?
+      <a href="https://github.com/rust-lang/beta.rust-lang.org" target="_blank" rel="noopener">Send a fix here</a>!
     </div>
   </div>
 </footer>


### PR DESCRIPTION
I the vein of [avoiding click here](https://www.w3.org/QA/Tips/noClickHere) links this PR changes the footer to link all of the, "Send a fix here", text. This probably still isn't ideal but I think it's an improvement on linking just to "here".