### PR TITLE
fix for a typo in crate's name

### DIFF
--- a/templates/learn/get-started.hbs
+++ b/templates/learn/get-started.hbs
@@ -79,7 +79,7 @@
       <p>In our <code>Cargo.toml</code> file we’ll add this information (that we got from the crate page):</p>
       <p>
         <pre><code>[dependencies]
-ferris_says = "0.1"</code></pre>
+ferris-says = "0.1"</code></pre>
       </p>
       <p>Now we can run:</p>
       <p><code>cargo build</code></p>


### PR DESCRIPTION
#438 - should be "ferris-says" instead of "ferris_says"