### PR TITLE
Update social media cards and meta tags to reflect the new slogan

### DIFF
--- a/templates/layout.hbs
+++ b/templates/layout.hbs
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <title>{{title}}</title>
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
-    <meta name="description" content="A systems programming language that runs blazingly fast, prevents segfaults, and guarantees thread safety.">
+    <meta name="description" content="The programming language that empowers everyone to become a systems programmer.">
 
     <!-- Twitter card -->
     <meta name="twitter:card" content="summary">

--- a/templates/layout.hbs
+++ b/templates/layout.hbs
@@ -11,12 +11,12 @@
     <meta name="twitter:site" content="@rustlang">
     <meta name="twitter:creator" content="@rustlang">
     <meta name="twitter:title" content="{{title}}">
-    <meta name="twitter:description" content="A systems programming language that runs blazingly fast, prevents segfaults, and guarantees thread safety.">
+    <meta name="twitter:description" content="The programming language that empowers everyone to become a systems programmer.">
     <meta name="twitter:image" content="http://new-rust-www.herokuapp.com/static/images/rust-social.jpg">
 
     <!-- Facebook OpenGraph -->
     <meta property="og:title" content="{{title}}" />
-    <meta property="og:description" content="A systems programming language that runs blazingly fast, prevents segfaults, and guarantees thread safety.">
+    <meta property="og:description" content="The programming language that empowers everyone to become a systems programmer.">
     <meta property="og:image" content="http://new-rust-www.herokuapp.com/static/images/rust-social-wide.jpg" />
     <meta property="og:type" content="website" />
     <meta property="og:locale" content="en_US" />


### PR DESCRIPTION
Saw some tweets about the new rust site, and did a quick fix for the Twitter cards. It looks like there's already issue #394 up for this. Does this look good?