### PR TITLE
addition of "extern crate ferris_says" to the example

### DIFF
--- a/templates/learn/get-started.hbs
+++ b/templates/learn/get-started.hbs
@@ -95,7 +95,7 @@ use ferris_says::say;</code></pre>
       <p>These lines mean that we can now use the <code>say</code> function that the <code>ferris-says</code> crate
         exports for us. When importing a crate that has dashes in its name like "ferris-says", which is not a valid Rust 
         identifier, it will be converted by changing the dashes to underscores, so you would write 
-        <code>extern crate ferris_says;</code>.</p>
+        <code>ferris_says</code>.</p>
   </div>
 </section>
 

--- a/templates/learn/get-started.hbs
+++ b/templates/learn/get-started.hbs
@@ -108,7 +108,7 @@ use ferris_says::say;</code></pre>
     <p>Now let’s write a small application with our new dependency. In our <code>main.rs</code>, add the following
       code:</p>
     <p>
-      <pre><code>extern crate ferris_says; // tells Rust that we need to compile and link to the ferris_crate crate.
+      <pre><code>extern crate ferris_says; // tells Rust that we need to compile and link to the ferris_says crate.
 
 use ferris_says::say; // from the previous step
 use std::io::{stdout, BufWriter};

--- a/templates/learn/get-started.hbs
+++ b/templates/learn/get-started.hbs
@@ -89,10 +89,13 @@ ferris-says = "0.1"</code></pre>
       <p>To use this dependency, we can open <code>main.rs</code>, remove everything that’s in there (it’s just another
         example), and add this line to it:</p>
       <p>
-        <pre><code>use ferris_says::say;</code></pre>
+        <pre><code>extern crate ferris_says;
+use ferris_says::say;</code></pre>
       </p>
-      <p>This line means that we can now use the <code>say</code> function that the <code>ferris-says</code> crate
-        exports for us.</p>
+      <p>These lines mean that we can now use the <code>say</code> function that the <code>ferris-says</code> crate
+        exports for us. When importing a crate that has dashes in its name lie "ferris-says", which is not a valid Rust 
+        identifier, it will be converted by changing the dashes to underscores, so you would write 
+        <code>extern crate ferris_say;</code>.</p>
   </div>
 </section>
 
@@ -105,7 +108,9 @@ ferris-says = "0.1"</code></pre>
     <p>Now let’s write a small application with our new dependency. In our <code>main.rs</code>, add the following
       code:</p>
     <p>
-      <pre><code>use ferris_says::say; // from the previous step
+      <pre><code>extern crate ferris_says; // tells Rust that we need to compile and link to the ferris_crate crate.
+
+use ferris_says::say; // from the previous step
 use std::io::{stdout, BufWriter};
 
 fn main() {

--- a/templates/learn/get-started.hbs
+++ b/templates/learn/get-started.hbs
@@ -95,7 +95,7 @@ use ferris_says::say;</code></pre>
       <p>These lines mean that we can now use the <code>say</code> function that the <code>ferris-says</code> crate
         exports for us. When importing a crate that has dashes in its name like "ferris-says", which is not a valid Rust 
         identifier, it will be converted by changing the dashes to underscores, so you would write 
-        <code>extern crate ferris_say;</code>.</p>
+        <code>extern crate ferris_says;</code>.</p>
   </div>
 </section>
 

--- a/templates/learn/get-started.hbs
+++ b/templates/learn/get-started.hbs
@@ -87,13 +87,13 @@ ferris-says = "0.1"</code></pre>
       <p>You’ll see that running this command created a new file for us, <code>Cargo.lock</code>. This file is a log of
         the exact versions of the dependencies we are using locally.</p>
       <p>To use this dependency, we can open <code>main.rs</code>, remove everything that’s in there (it’s just another
-        example), and add this line to it:</p>
+        example), and add these two lines to it:</p>
       <p>
         <pre><code>extern crate ferris_says;
 use ferris_says::say;</code></pre>
       </p>
       <p>These lines mean that we can now use the <code>say</code> function that the <code>ferris-says</code> crate
-        exports for us. When importing a crate that has dashes in its name lie "ferris-says", which is not a valid Rust 
+        exports for us. When importing a crate that has dashes in its name like "ferris-says", which is not a valid Rust 
         identifier, it will be converted by changing the dashes to underscores, so you would write 
         <code>extern crate ferris_say;</code>.</p>
   </div>


### PR DESCRIPTION
I was not able to build the program without `extern crate ferris_says`, the build was failing with error[E0432]: unresolved import `ferris_says`