### PR TITLE
Wrap the book title in <cite>

### DIFF
--- a/templates/learn/index.hbs
+++ b/templates/learn/index.hbs
@@ -14,10 +14,10 @@
     </header>
     <div class="flex flex-column flex-row-l justify-between">
       <section class="pt0">
-        <p>Affectionately nicknamed “the book,” The Rust Programming Language
-          will give you an overview of the language from first principles.
-          You’ll build a few projects along the way, and by the end, you’ll have
-        a solid grasp of the language.</p>
+        <p>Affectionately nicknamed “the book,” <cite>The Rust Programming
+          Language</cite> will give you an overview of the language from first
+          principles. You’ll build a few projects along the way, and by the end,
+          you’ll have a solid grasp of the language.</p>
           <a class="button button-secondary" href="https://doc.rust-lang.org/book/">Read the Book!</a>
       </section>
       <section class="pl5-l pt4 pt0-l">


### PR DESCRIPTION
This is in reference to #451.

The problem is that the book title should be italicized. To do that, I've wrapped the title in a `<cite>`, but I've not touched the styles. Most (all?) browsers render `<cite>` in italics, but I don't think any spec requires them to do so.

Is it OK to rely on browser default styles?

