### PR TITLE
fixed typo in Ferris section of get started page

### DIFF
--- a/templates/learn/get-started.hbs
+++ b/templates/learn/get-started.hbs
@@ -154,7 +154,7 @@ fn main() {
       <div class="highlight"></div>
     </header>
     <p>Ferris (they/them) is the unofficial mascot of the Rust Community. Rust programmers call themselves
-      "Rustaceans", which is a play on the word "crustacean", which is set of creatures, one of which is a crab!</p>
+      "Rustaceans", which is a play on the word "crustacean", which is a set of creatures, one of which is a crab!</p>
     <p>Ferris is a name playing off of the adjective, "ferrous", meaning of or pertaining to iron. Since Rust often
       forms on iron, it seemed like a fun origin for our mascot’s name!</p>
     <p>You can find more images of Ferris on <a href="http://rustacean.net/" target="_blank" rel="noopener">http://rustacean.net/</a>.


### PR DESCRIPTION
I fixed the "which is set of creatures" phrase in the Ferris section at the bottom of the Get Started page.  It had a typo where it was missing an 'a'.  