### PR TITLE
Add IRC link back to community page

### DIFF
--- a/templates/community/index.hbs
+++ b/templates/community/index.hbs
@@ -60,13 +60,18 @@
           <h3>Chat platforms</h3>
           <p>
             Development of Rust, and general chatter happens on several chat
-            platforms. Check out general channels and more on the Rust Discord server,
-            or check out the teams page to find where specific teams meet.
+            platforms. Our primary chat platform is the Mozilla IRC server.
+            You can also check out general channels and more on the Rust
+            Discord server, or check out the teams page to find where specific
+            teams meet.
           </p>
         </div>
 
         {{!-- TODO: remove padding and margin once global declarations are gone --}}
         <ul class="list pa0 ma0"> 
+          <li>
+            <a href="https://kiwiirc.com/nextclient/irc.mozilla.org:+6697/#rust" target="_blank" rel="noopener" class="button button-primary">IRC (irc.mozilla.org #rust)</a>
+          </li>
           <li>
             <a href="https://discord.gg/rust-lang" target="_blank" rel="noopener" class="button button-secondary">Discord</a>
           </li>


### PR DESCRIPTION
We have not yet had a community discussion on replacing IRC with Discord. Discord is a proprietary chat platform with a variety of well-documented issues, including accessibility concerns. I believe that it is unacceptable to force this change on the community, as it means that in order to communicate about and contribute to Rust, Discord must be used. As much as both @ashleygwilliams and @steveklabnik have been attempting to sneak this under the table by fending off any criticism with repeated assertions that IRC is not being killed off, the removal of the link shows that it evidently is.

As a result, this change moves Discord into a secondary link, with IRC being the primary link, and this should remain the case until there is a community discussion on this topic.