### PR TITLE
Don't say "other classes of bugs" without antecedent for "other"

### DIFF
--- a/templates/panels/language-values.hbs
+++ b/templates/panels/language-values.hbs
@@ -19,8 +19,8 @@
         <h3 class="f2 f1-l">Reliability</h3>
         <p class="f3 lh-copy">
           Rust’s rich type system and ownership model guarantee memory-safety
-          and thread-safety &mdash; and enable you to eliminate many other
-          classes of bugs at compile-time.
+          and thread-safety &mdash; and enable you to eliminate many classes of
+          bugs at compile-time.
         </p>
       </section>
       <section class="flex flex-column mw8 measure-wide-l pv3 pt4-ns pl4-l">


### PR DESCRIPTION
This patch changes the file `templates/panels/language-values.hbs`, where it promotes Rust as enabling the reader "to eliminate many other classes of bugs at compile-time", to say "to eliminate many classes of bugs at compile-time" instead, without the word "other", because no classes of bugs per se previously are mentioned, leaving "other" lacking an antecedent.

Per `CONTRIBUTING.md`, I have filed [an issue ticket][1] first to suggest this change; the change was approved, and this patch requested, by @aturon.

GitHub: Resolve rust-lang/beta.rust-lang.org#476

[1]: <https://github.com/rust-lang/beta.rust-lang.org/issues/476>