### PR TITLE
Fix #477: Replace "a multi-editor language server"

### DIFF
--- a/templates/panels/language-values.hbs
+++ b/templates/panels/language-values.hbs
@@ -28,8 +28,8 @@
         <p class="f3 lh-copy">
           Rust has great documentation, a friendly compiler with useful error
           messages, and top-notch tooling &mdash; an integrated package manager
-          and build tool, a multi-editor language server, an auto-formatter, and
-          more.
+          and build tool, smart multi-editor support with auto-completion and 
+          type inspections, an auto-formatter, and more.
         </p>
       </section>
 


### PR DESCRIPTION
with a description of its effects on editor support.

(This will also encompass support that is not built on top of RLS such as Intellij.)