### PR TITLE
Mention `rustup upgrade` in install instructions

### DIFF
--- a/templates/tools/install.hbs
+++ b/templates/tools/install.hbs
@@ -40,6 +40,10 @@
         cross-compilation targets.
       </p>
       <p>
+        If you've installed <code>rustup</code> in the past, you can update
+        your installation by running <code>rustup upgrade</code>.
+      </p>
+      <p>
         For more information see the
         <a href="https://github.com/rust-lang-nursery/rustup.rs/blob/master/README.md" target="_blank" rel="noopener"><code>rustup</code>
         documentation</a>.


### PR DESCRIPTION
I had installed `rustup` a while ago but sat down today to try Rust again; it wasn't obvious to me how to get the latest Rust.