### PR TITLE
switch to overflow: scroll to auto on code tags

### DIFF
--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -28,7 +28,7 @@ body {
 }
 
 code {
-  overflow: scroll;
+  overflow: auto;
 }
 
 .button.button-secondary {


### PR DESCRIPTION
Hide scroll bars unless needed on Linux and Windows desktops as discussed here https://github.com/rust-lang/beta.rust-lang.org/issues/402