### PR TITLE
Make top margin of footer columns consistent

### DIFF
--- a/templates/footer.hbs
+++ b/templates/footer.hbs
@@ -1,7 +1,7 @@
 <footer>
   <div class="w-100 mw-none ph3 mw8-m mw9-l center f3">
     <div class="row">
-      <div class="four columns" id="get-help">
+      <div class="four columns mt3 mt0-l" id="get-help">
         <h4>Get help!</h4>
         <ul>
           <li><a href="https://doc.rust-lang.org" target="_blank" rel="noopener">Documentation</a></li>
@@ -12,7 +12,7 @@
           {{> languages-dropdown }}
         </div>
       </div>
-      <div class="four columns mt5 mt0-l">
+      <div class="four columns mt3 mt0-l">
         <h4>Terms and policies</h4>
         <ul>
           <li><a href="/policies/code-of-conduct">Code of Conduct</a></li>


### PR DESCRIPTION
I noticed the top margins of the footer columns were inconsistent (3 different top margins) and it looked like a bug. Feel free to close if it was intended.

**Fix:**
![image](https://user-images.githubusercontent.com/13814048/49345361-897be600-f638-11e8-98e5-200aebc8a9fb.png)

**Previous:**
![image](https://user-images.githubusercontent.com/13814048/49345372-a3b5c400-f638-11e8-87e1-dd33185938c4.png)
