### PR TITLE
fix(testimonials): Vertically align testimonials everywhere

### DIFF
--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -619,13 +619,11 @@ blockquote::before {
   display: none;
 }
 
-.vertical-center {
+.testimonial {
   display: flex;
   align-items: center;
-}
-
-@media only screen and (max-width: 545px) {
-  .vertical-center {
+  
+  @media only screen and (max-width: 545px) {
     display: block;
   }
 }

--- a/templates/what/networking/production.hbs
+++ b/templates/what/networking/production.hbs
@@ -5,7 +5,7 @@
             <div class="highlight"></div>
         </header>
         <div class="testimonials">
-            <div class="testimonial row vertical-center">
+            <div class="testimonial row">
                 <div class="four columns">
                     <img src="/static/images/firefox.png" />
                 </div>
@@ -21,7 +21,7 @@
                     </p>
                 </div>
             </div>
-            <div class="testimonial row vertical-center">
+            <div class="testimonial row">
                 <div class="eight columns">
                     <blockquote>
                         Rust is foundational to the Linkerd project’s technology roadmap. Its type system allows us to


### PR DESCRIPTION
#447 @ashleygwilliams Turns out the `testimonial` class was not yet defined. I've defined it as the same as `vertical-center` from before. The changes then will propagate across all testimonials on the site. 