### PR TITLE
Add relevant titles to pages

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,7 @@ use production::User;
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::prelude::*;
+use std::iter::FromIterator;
 use std::path::{Path, PathBuf};
 
 use rand::seq::SliceRandom;
@@ -60,6 +61,13 @@ struct UsersContext {
     data: Vec<Vec<User>>,
 }
 
+fn get_title(page_name: &str) -> String {
+    let mut v: Vec<char> = page_name.replace("-", " ").chars().collect();
+    v[0] = v[0].to_uppercase().nth(0).unwrap();
+    let page_name = String::from_iter(v);
+    format!("{} - Rust programming language", page_name).to_string()
+}
+
 #[get("/")]
 fn index() -> Template {
     #[derive(Serialize)]
@@ -72,7 +80,7 @@ fn index() -> Template {
     }
 
     let page = "index".to_string();
-    let title = format!("Rust - {}", page).to_string();
+    let title = "Rust programming language".to_string();
 
     let context = Context {
         page: page.clone(),
@@ -93,7 +101,7 @@ fn files(file: PathBuf) -> Option<NamedFile> {
 #[get("/<category>")]
 fn category(category: Category) -> Template {
     let page = category.index();
-    let title = format!("Rust - {}", page).to_string();
+    let title = get_title(&category.name());
     let context = Context {
         page: category.name().to_string(),
         title: title,
@@ -106,7 +114,7 @@ fn category(category: Category) -> Template {
 #[get("/governance")]
 fn governance() -> Template {
     let page = "governance/index".to_string();
-    let title = format!("Rust - {}", page).to_string();
+    let title = "Governance - Rust programming language".to_string();
     let context = GroupContext {
         page: page.clone(),
         title: title,
@@ -133,8 +141,8 @@ fn load_governance_data() -> HashMap<String, Vec<Group>> {
 #[get("/governance/<t>/<subject>", rank = 2)]
 fn team(t: String, subject: String) -> Template {
     let page = "governance/group".to_string();
-    let title = format!("Rust - {}", page).to_string();
     let t = get_type_from_string(&t).expect("couldnt figure out group type from path string");
+    let title = get_title(&format!("{} team", subject));
     let context = GroupContext {
         page: page.clone(),
         title: title,
@@ -177,7 +185,7 @@ fn load_group_data(t: GroupType, group: &str) -> HashMap<String, Vec<Group>> {
 #[get("/production/users")]
 fn production() -> Template {
     let page = "production/users".to_string();
-    let title = format!("Rust - {}", page).to_string();
+    let title = "Users - Rust programming language".to_string();
     let context = UsersContext {
         page: page.clone(),
         title: title,
@@ -198,7 +206,7 @@ fn load_users_data() -> Vec<Vec<User>> {
 #[get("/<category>/<subject>", rank = 4)]
 fn subject(category: Category, subject: String) -> Template {
     let page = format!("{}/{}", category.name(), subject.as_str()).to_string();
-    let title = format!("Rust - {}", page).to_string();
+    let title = get_title(&subject);
     let context = Context {
         page: subject,
         title: title,
@@ -211,7 +219,7 @@ fn subject(category: Category, subject: String) -> Template {
 #[catch(404)]
 fn not_found() -> Template {
     let page = "404";
-    let title = format!("Rust - {}", page).to_string();
+    let title = format!("{} - Rust programming language", page).to_string();
     let context = Context {
         page: "404".to_string(),
         title: title,
@@ -241,6 +249,7 @@ fn main() {
         .mount(
             "/",
             routes![index, category, governance, team, production, subject, files],
-        ).catch(catchers![not_found, catch_error])
+        )
+        .catch(catchers![not_found, catch_error])
         .launch();
 }


### PR DESCRIPTION
Fixes #330 
I would welcome feedback if any.

It adds better title (as in the <head><title>) to pages.

| Site path | page title |
| --- | --- |
| / | Rust programming language |
| /lean | Learn - Rust programming language |
| /learn/get-started | Get started - Rust programming language |
| /what/cli | Cli - Rust programming language |
| /what/wasm | Wasm - Rust programming language |
| /what/networking | Networking - Rust programming language |
| /what/embedded | Embedded - Rust programming language |
| /tools | Tools - Rust programming language |
| /community | Community - Rust programming language |
| /governance | Governance - Rust programming language |
| /governance/teams/moderation | Moderation team - Rust programming language |
| /governance/teams/crates-io | Crates.io team - Rust programming language |
| /governance/wgs/wasm | Wasm team - Rust programming language |
| /policies/code-of-conduct | Code of conduct - Rust programming language |
| /policies/licenses | Licenses - Rust programming language |
| /production | Production - Rust programming language |
| /production/users | Users - Rust programming language |

I did not follow exactly https://github.com/rust-lang/beta.rust-lang.org/issues/330#issuecomment-440026473

I followed a pattern similar to the Rust book for instance https://doc.rust-lang.org/book/2018-edition/ch03-03-how-functions-work.html
In the browser tab we see the relevant part even when the tab has a narrow width but we still keep some context.

Capitalization could need a change, or a "The" before "Rust programming language" could be relevant.

I would welcome any feedback ;)