### PR TITLE
feat(styles): reduce intensity of yellow

### DIFF
--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -7,7 +7,7 @@ $gray: #454C52;
 $red: #C14566;
 $green: #398277;
 $purple: #403D58;
-$yellow: #FECD2F;
+$yellow: #FFD45E;
 
 body {
   font-family: $body-font;


### PR DESCRIPTION
fixe #408 

now
<img width="321" alt="screen shot 2018-12-04 at 11 59 21 am" src="https://user-images.githubusercontent.com/1163554/49459026-11d6c400-f7bc-11e8-8963-746c40741d90.png">

before
<img width="348" alt="screen shot 2018-12-04 at 11 59 13 am" src="https://user-images.githubusercontent.com/1163554/49459027-11d6c400-f7bc-11e8-8ee3-d4d03bf92f8d.png">


<hr/>


![screenshot_2018-12-04 rust - index](https://user-images.githubusercontent.com/1163554/49458920-d89e5400-f7bb-11e8-98a6-4cc615245ed5.png)
