### PR TITLE
fix(community): align 'where to talk' buttons.

### DIFF
--- a/templates/community/index.hbs
+++ b/templates/community/index.hbs
@@ -29,7 +29,7 @@
       <div class="highlight"></div>
     </header>
     <div class="flex flex-column flex-row-l">
-      <div class="mw-33-l mh3-l pt0 flex flex-column justify-between" id="users-forum">
+      <div class="mw-33-l mh3-l pt0 flex flex-column justify-start" id="users-forum">
         <div>
           <h3>Users forum</h3>
           <p>
@@ -43,19 +43,20 @@
           Forum</a>
       </div>
 
-      <div class="mw-33-l mh3-l pt4 pt0-l flex flex-column justify-between" id="internals-forum">
+      <div class="mw-33-l mh3-l pt4 pt0-l flex flex-column justify-start" id="internals-forum">
         <div>
           <h3>Internals forum</h3>
           <p>
             The Rust Internals Forum is a place for discussion about the
-            development of Rust itself.
+            development of Rust itself &ndash; including work on the compiler
+            as well as the design of the language and the standard library.
           </p>
         </div>
         <a href="https://internals.rust-lang.org/" target="_blank" rel="noopener" class="button button-secondary">Visit
           Forum</a>
       </div>
 
-      <div class="mw-33-l mh3-l pt4 pt0-l flex flex-column justify-between" id="chat-platforms">
+      <div class="mw-33-l mh3-l pt4 pt0-l flex flex-column justify-start" id="chat-platforms">
         <div>
           <h3>Chat platforms</h3>
           <p>


### PR DESCRIPTION
This is a bit of a hack, in truth: this only works by making the lines all render at roughly the same length. Unfortunately, there are not a lot of great alternatives without CSS Grid, and we would need Autoprefixer to support that.

Fixes #551.

<img width="1047" alt="screen shot 2018-12-04 at 7 58 36 pm" src="https://user-images.githubusercontent.com/2403023/49487310-06f15300-f7ff-11e8-8a8d-74ee8ab4e3f4.png">
