### PR TITLE
Improve consistency and bump text size.

### DIFF
--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -59,7 +59,7 @@ header h1, section h2 {
 }
 
 header h1 {
-  font-size: 10rem;
+  font-size: 8rem;
   margin-bottom: 0;
   margin-top: 0;
 }
@@ -71,7 +71,7 @@ header .button.button-primary.button-download {
   width: 100%;
   padding: 20px;
   height: auto;
-  font-size: 2em;
+  font-size: 2.25rem;
   margin-top: 20px;
 }
 
@@ -271,7 +271,7 @@ a.brand {
 
 h3 {
   font-weight: 800; 
-  font-size: 1.8em;
+  font-size: 1.5em;
   letter-spacing: normal;
 }
 
@@ -350,10 +350,6 @@ blockquote::before {
 
 #production .attribution {
   text-align: right;
-}
-
-.production p {
-  font-size: 3rem;
 }
 
 .production .button.button-secondary {

--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -9,6 +9,16 @@ $green: #398277;
 $purple: #403D58;
 $yellow: #FFD45E;
 
+html {
+  font-size: 62.5%
+}
+
+@media screen and (min-width: 30em) {
+  html {
+    font-size: 75%;
+  }
+}
+
 body {
   font-family: $body-font;
   background-color: white;

--- a/templates/governance/index.hbs
+++ b/templates/governance/index.hbs
@@ -3,7 +3,7 @@
 <header class="mt3 mt2-ns mb4 mb5-ns tc tl-ns">
   <div class="w-100 mw-none ph3 mw8-m mw9-l center f3">
     <h1>Governance</h1>
-    <h2 class="subtitle">How Rust is built by its community</h2>
+    <h2 class="f2 f1-ns mt0">How Rust is built by its community</h2>
   </div>
 </header>
 

--- a/templates/panels/production.hbs
+++ b/templates/panels/production.hbs
@@ -1,11 +1,11 @@
 <section class="white production">
-  <div class="w-100 mw-none ph3 mw8-m mw9-l center f3">
+  <div class="w-100 mw-none ph3 mw8-m mw9-l center">
     <header>
       <h2>Rust in production</h2>
       <div class="highlight"></div>
     </header>
     <div class="description">
-      <p>
+      <p class="lh-copy f2">
         Hundreds of companies around the world are using Rust in production
         today for fast, low resource, cross-platform solutions. Software you know
         and love, like <a href="https://hacks.mozilla.org/2017/08/inside-a-super-fast-css-engine-quantum-css-aka-stylo/" target="_blank" rel="noopener">Firefox</a>, <a href="https://blogs.dropbox.com/tech/2016/06/lossless-compression-with-brotli/" target="_blank" rel="noopener">Dropbox</a>, and <a href="https://blog.cloudflare.com/cloudflare-workers-as-a-serverless-rust-platform/" target="_blank" rel="noopener">Cloudflare</a>, uses Rust. <strong>From startups to large
@@ -15,7 +15,7 @@
     <div class="testimonials">
       <div class="testimonial row">
         <div class="eight columns" id="chucklefish-testimonial">
-          <blockquote>
+          <blockquote class="lh-title-ns">
             Rust is one of the few languages that really gives you a large amount of confidence that your parallel and
             concurrent code is anywhere near correct.
           </blockquote>


### PR DESCRIPTION
This is a first step toward addressing some of the points raised in #525. I substantially increased the type size on all pages by setting a `font-size` in `html` when past the "small" screen size breakpoint specified by Tachyons. This has a couple of benefits:

- It increases the perceived contrast between text and background throughout the site, which alleviates many of the readability issues people have, when on larger screens (if we do the same on smaller screens, we end up costing ourselves information density, which we really don't want)
- It allows us to decrease some of the text sizes for specific headings and so on, bringing them inline with the Tachyons type scale. This increases the sense of coherence and consistency throughout the site.

On that latter note, I also shifted a few items to use Tachyons classes instead of hard-coded values, bringing line-heights and font-sizes in line with Tachyons and thereby helping them fit together a bit better (see esp. the "Rust in Production" section on the home page – there's still work to do, but it's at least much *better*).

<details><summary>Here's how it looks on big screens</summary>

![larger-text](https://user-images.githubusercontent.com/2403023/49488581-7453b280-f804-11e8-99f2-ba56caf22dd2.png)

</details>

I'm by no means married to the specific base text size I chose, but I think this starts to get us in the right direction.