### PR TITLE
Changed Cofusing button names in Get Involved section [ fix #430 ]

### DIFF
--- a/templates/panels/get-involved.hbs
+++ b/templates/panels/get-involved.hbs
@@ -11,13 +11,13 @@
             <h3>Read Rust</h3>
             <p>We love documentation! Take a look at the books available online, as well as key blog posts and user
               guides.</p>
-            <a href="learn" class="button button-secondary">Get Started</a>
+            <a href="learn" class="button button-secondary">Read the book</a>
           </div>
           <div class="six columns" id="watch-rust">
             <h3>Watch Rust</h3>
             <p>The Rust community has a dedicated YouTube channel collecting a huge range of presentations and
               tutorials.</p>
-            <a href="https://www.youtube.com/channel/UCaYhcUwRBNscFNUKTjgPFiA" class="button button-secondary">Check it out</a>
+            <a href="https://www.youtube.com/channel/UCaYhcUwRBNscFNUKTjgPFiA" class="button button-secondary">Watch the Videos</a>
           </div>
         </div>
         <div class="pt3">
@@ -27,7 +27,7 @@
             newcomers and seasoned professionals. Come help us make the Rust experience even better!
           </p>
           <a href="https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.md" class="button button-secondary" target="_blank" rel="noopener">
-            Learn More
+            Read Contribution Guide
           </a>
         </div>
       </div>


### PR DESCRIPTION
Changed the names of the buttons in the Get Involved section according to the suggestion in issue #430 :
"Get started" -> "Read the book"
"Check it out" -> "Watch the videos"
"Learn more" -> "Read contribution guide"